### PR TITLE
Fixed potential bug with -MINIMUM_VALUE

### DIFF
--- a/to_string.hpp
+++ b/to_string.hpp
@@ -23,7 +23,7 @@ struct to_string_t {
     // fits to the number perfectly.
     char buf[([] {
                   unsigned int len = N >= 0 ? 1 : 2;
-                  for (auto n = N < 0 ? -N : N; n; len++, n /= base);
+                  for (auto n = N; n; len++, n /= base);
                   return len;
              }())];
 
@@ -33,8 +33,8 @@ struct to_string_t {
     constexpr to_string_t() {
         auto ptr = buf + sizeof(buf) / sizeof(buf[0]);
         *--ptr = '\0';
-        for (auto n = N < 0 ? -N : N; n; n /= base)
-            *--ptr = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[n % base];
+        for (auto n = N; n; n /= base)
+            *--ptr = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[(N < 0 ? -1 : 1) * (n % base)];
         if (N < 0)
             *--ptr = '-';
     }

--- a/to_string.hpp
+++ b/to_string.hpp
@@ -15,7 +15,7 @@
  * @tparam N Number to convert
  * @tparam base Desired base, can be from 2 to 36
  */
-template<auto N, unsigned int base, typename char_type,
+template<auto N, int base, typename char_type,
     std::enable_if_t<std::is_integral_v<decltype(N)>, int> = 0,
     std::enable_if_t<(base > 1 && base < 37), int> = 0>
 class to_string_t {
@@ -35,7 +35,7 @@ class to_string_t {
         auto ptr = end();
         *--ptr = '\0';
         if (N != 0) {
-            for (auto n = N < 0 ? -N : N; n; n /= base)
+            for (auto n = N; n; n /= base)
                 *--ptr = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[(N < 0 ? -1 : 1) * (n % base)];
             if (N < 0)
                 *--ptr = '-';


### PR DESCRIPTION
Original code had something like `N < 0 ? -N : N` which could fail if `N` has minimum value of appropriate type. For example, in original code this could fail:
```cpp
const long long int LL_MIN = std::numeric_limits<long long int>::min(); //probably: -9223372036854775808
static const char *number = to_string<LL_MIN, 10>;
```

Also note that this code relies on "modulo on negative first operands" which was implementation defined in C++03 and before, but with C++11 and later it is defined by standard (see `ISO14882:2011(e)`), and this code anyway targets C++17 so we're safe here.