### PR TITLE
Removing magic constant from template param check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ The integer/string conversion is done using a simple method I learned over the y
 (*Note: The below examples of code are not up-to-date, though they still give a general idea of how `to_string` works.*)
 
 ```cpp
+constexpr char digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
 constexpr to_string_t() {
     auto ptr = buf + sizeof(buf) / sizeof(buf[0]);
     *--ptr = '\0';
     for (auto n = N < 0 ? -N : N; n; n /= base)
-        *--ptr = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[n % base];
+        *--ptr = digits[n % base];
     if (N < 0)
         *--ptr = '-';
 }

--- a/to_string.hpp
+++ b/to_string.hpp
@@ -9,6 +9,9 @@
 
 #include <type_traits>
 
+constexpr char digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+constexpr auto digit_count = sizeof(digits) / sizeof(digits[0]);
+
 /**
  * @struct to_string_t
  * @brief Provides the ability to convert any integral to a string at compile-time.
@@ -17,7 +20,7 @@
  */
 template<auto N, unsigned int base, typename char_type,
     std::enable_if_t<std::is_integral_v<decltype(N)>, int> = 0,
-    std::enable_if_t<(base > 1 && base < 37), int> = 0>
+    std::enable_if_t<(base > 1 && base < digit_count), int> = 0>
 struct to_string_t {
     // The lambda calculates what the string length of N will be, so that `buf`
     // fits to the number perfectly.
@@ -35,7 +38,7 @@ struct to_string_t {
             auto ptr = buf + sizeof(buf) / sizeof(buf[0]);
             *--ptr = '\0';
             for (auto n = N < 0 ? -N : N; n; n /= base)
-                *--ptr = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[n % base];
+                *--ptr = digits[n % base];
             if (N < 0)
                 *--ptr = '-';
         } else {

--- a/to_string.hpp
+++ b/to_string.hpp
@@ -9,6 +9,8 @@
 
 #include <type_traits>
 
+namespace constexpr_to_string {
+
 constexpr char digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 constexpr auto digit_count = sizeof(digits) / sizeof(digits[0]);
 
@@ -68,10 +70,12 @@ class to_string_t {
     constexpr const auto end() const noexcept { return buf + size(); }
 };
 
+} // namespace constexpr_to_string
+
 /**
  * Simplifies use of `to_string_t` from `to_string_t<N>()` to `to_string<N>`.
  */
 template<auto N, int base = 10, typename char_type = char>
-constexpr to_string_t<N, base, char_type> to_string;
+constexpr constexpr_to_string::to_string_t<N, base, char_type> to_string;
 
 #endif // TCSULLIVAN_TO_STRING_HPP_


### PR DESCRIPTION
Storing digits in variable, thus removing magic constant from template param check.